### PR TITLE
Pin the version of jekyll-sass-converter to 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :jekyll_plugins do
   gem "jekyll-last-modified-at", "~> 1.3"
   gem "jekyll-minifier", "~> 0.1"
   gem "jekyll-paginate", "~> 1.1"
+  gem "jekyll-sass-converter", "~> 2.2"
   gem "jekyll-sitemap", "~> 1.4"
   gem "jekyll-target-blank", "~> 2.0"
   gem "jemoji", "~> 0.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ DEPENDENCIES
   jekyll-last-modified-at (~> 1.3)
   jekyll-minifier (~> 0.1)
   jekyll-paginate (~> 1.1)
+  jekyll-sass-converter (~> 2.2)
   jekyll-sitemap (~> 1.4)
   jekyll-target-blank (~> 2.0)
   jemoji (~> 0.13)


### PR DESCRIPTION
Because updating to Jekyll v4.3.2 causes sass warnings.
ref) https://github.com/mmistakes/minimal-mistakes/issues/4054#issuecomment-1371015867
